### PR TITLE
workaround to mark exceptions

### DIFF
--- a/KodiLog.sublime-syntax
+++ b/KodiLog.sublime-syntax
@@ -14,6 +14,8 @@ contexts:
           scope: invalid.illegal
         - match: 'EXCEPTION Thrown \(PythonToCppException\) : -->Python callback/script returned the following error<--'
           scope: invalid.illegal
+        - match: (?<=                                            ).*
+          scope: invalid.illegal
         - match: '-->End of Python script error report<--'
           scope: invalid.illegal
         - match: \b(NOTICE)\b


### PR DESCRIPTION
@jindaxia I had to use a workaround because multiline RegEx does not seem to work for syntax highlighting. Could you check if this works well enough?
